### PR TITLE
Fixing the errors for v0.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.5
 Primes
+Compat

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,6 +1,6 @@
-import Base: ==, isless, <=, <, >, 
+import Base: ==, isless, <=, <, >,
     +, -, *, ^, max, min, div, %, gcd, lcm,
-    isqrt, isodd, iseven, one, isprime, factor, primes
+    isqrt, isodd, iseven, one
 
 # Remember that RN is typealiased to RomanNumeral
 
@@ -34,11 +34,11 @@ for op in [:isodd, :iseven, :isprime]
 end
 
 # Who knew Romans did number theory
-function Base.factor(num::RN)
+function Primes.factor(num::RN)
     factors = Dict{RN,RN}()
     for (fac, mul) in factor(num.val)
         factors[RN(fac)] = RN(mul)
     end
     factors
 end
-Base.primes(num::RN) = map(RN, primes(num.val))
+Primes.primes(num::RN) = map(RN, Primes.primes(num.val))

--- a/src/roman_conversion.jl
+++ b/src/roman_conversion.jl
@@ -33,7 +33,7 @@ function parseroman(str::String)
     # Strip whitespace
     str = m.captures[1]
     # Make `str` uppercase
-    if !isupper(str); str = uppercase(str); end
+    if !all(isupper,str); str = uppercase(str); end
     i = 1
     val = 0
     strlen = length(str)

--- a/src/types.jl
+++ b/src/types.jl
@@ -20,7 +20,7 @@ macro rn_str(str)
     RomanNumeral(str)
 end
 
-typealias RN RomanNumeral
+const RN = RomanNumeral
 
 # Standard functions
 # Conversion + promotion
@@ -36,4 +36,4 @@ Base.print(io::IO, num::RN) = print(io, num.str)
 Base.show(io::IO, num::RN) = write(io, num.str)
 
 Base.length(num::RN) = length(num.str)
-Base.hash(num::RN) = hash(num.str) $ hash(num.val)
+Base.hash(num::RN) = xor(hash(num.str), hash(num.val))

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,3 +1,5 @@
+using Compat
+
 # Thrown when the string passed to `parseroman` is not a valid Roman numeral.
 type InvalidRomanError <: Exception
     str::String
@@ -36,4 +38,4 @@ Base.print(io::IO, num::RN) = print(io, num.str)
 Base.show(io::IO, num::RN) = write(io, num.str)
 
 Base.length(num::RN) = length(num.str)
-Base.hash(num::RN) = xor(hash(num.str), hash(num.val))
+Base.hash(num::RN) = @compat xor(hash(num.str), hash(num.val))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using RomanNumerals
 using Base.Test
+using Primes
 
 # Constructor tests
 @test RomanNumeral(46) == RomanNumeral("XLVI")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using RomanNumerals
 using Base.Test
 using Primes
+using Compat
 
 # Constructor tests
 @test RomanNumeral(46) == RomanNumeral("XLVI")
@@ -21,5 +22,5 @@ using Primes
 @test rn"XX" ^ rn"II" == rn"CD"
 
 # primus numeri et factorii (quis scit?)
-@test factor(rn"XX")[rn"V"]    == rn"I"
+@test @compat factor(rn"XX")[rn"V"]    == rn"I"
 @test length(primes(rn"XXIX")) == rn"X"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using RomanNumerals
 using Base.Test
 using Primes
-using Compat
 
 # Constructor tests
 @test RomanNumeral(46) == RomanNumeral("XLVI")
@@ -22,5 +21,5 @@ using Compat
 @test rn"XX" ^ rn"II" == rn"CD"
 
 # primus numeri et factorii (quis scit?)
-@test @compat factor(rn"XX")[rn"V"]    == rn"I"
+@test factor(rn"XX")[rn"V"]    == rn"I"
 @test length(primes(rn"XXIX")) == rn"X"


### PR DESCRIPTION
Mostly simple changes:

1. factors, isfactor and primes functions to be looked up from Primes package.
2. Include the `using Primes` wherever needed. 
3. xor in place of $.

All changes are looking 0.5 compatible, hence no @compat macro is used. 