### PR TITLE
Added support for numbers up to 1 million

### DIFF
--- a/src/roman_conversion.jl
+++ b/src/roman_conversion.jl
@@ -11,7 +11,22 @@ const VALID_ROMAN_PATTERN =
     \s*$                   # Skip trailing whitespace
     """ix # Be case-insensitive and verbose
 
+const OVERBAR_CHAR = Char(0x0305)
+_place_overbar(c::AbstractChar) = string(c, OVERBAR_CHAR)
+_place_overbar(s::AbstractString) = join(_place_overbar(c) for c in s)
+
 const NUMERAL_MAP = [
+    (1_000_000, _place_overbar("M"))
+    (500_000, _place_overbar("D"))
+    (100_000, _place_overbar("C"))
+    (50_000, _place_overbar("L"))
+    (10_000, _place_overbar("X"))
+    (9000, _place_overbar("IX"))
+    (8000, _place_overbar("VIII"))
+    (7000, _place_overbar("VII"))
+    (6000, _place_overbar("VI"))
+    (5000, _place_overbar("V"))
+    (4000, _place_overbar("IV"))
     (1000, "M")
     (900,  "CM")
     (500,  "D")
@@ -49,7 +64,7 @@ end
 using Compat: @warn
 function toroman(val::Integer)
     val <= 0 && throw(DomainError(val, "in ancient Rome there were only strictly positive numbers"))
-    val > 5000 && @warn("Roman numerals do not handle large numbers well")
+    val > maximum(first(t) for t in NUMERAL_MAP) && @warn("Roman numerals do not handle large numbers well") # instead if maximum, use NUMERAL_MAP[1][1]?
 
     str = IOBuffer()
     for (num_val, numeral) in NUMERAL_MAP


### PR DESCRIPTION
Possibly should remove `_place_overbar` function and just use the plain unicode characters.  Also, possibly should not have the `maximum` function call to get the maximum number this package supports.

See [here](http://www.romannumerals.co/learn/large-numbers/) for reference.  If we want to implement this in a more clever way, we should follow the process in the aforementioned link, and keep the `_place_overbar` function for that.