### PR TITLE
parsing improvements by gpapini-it

### DIFF
--- a/src/RomanNumerals.jl
+++ b/src/RomanNumerals.jl
@@ -3,9 +3,9 @@ module RomanNumerals
 # Defines the exception the struct RomanNumeral
 include("types.jl")
 
-# Defines the functions toroman and parse(RomanNumeral, x), to convert from
-# Roman-formatted string to int and vice versa
-include("roman_conversion.jl")
+# Defines the functions toroman, fromroman and parse(RomanNumeral, x), to
+# convert from Roman-formatted string to int and vice versa
+include("parsing.jl")
 
 # Defines new method dispatching specific to Roman numerals
 include("arithmetic.jl")

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -42,8 +42,7 @@ const NUMERAL_MAP = [
     (1,    "I")
 ]
 
-import Base: parse
-function parse(::Type{RomanNumeral}, str::AbstractString)
+function fromroman(str::AbstractString)
     m = match(VALID_ROMAN_PATTERN, str)
     m ≡ nothing && throw(Meta.ParseError(str * " is not a valid roman numeral"))
     # Strip whitespace and make uppercase
@@ -58,9 +57,13 @@ function parse(::Type{RomanNumeral}, str::AbstractString)
             i += numlen
         end
     end
-    val
+    return val
 end
 
+import Base: parse
+parse(::Type{RomanNumeral}, s::AbstractString) = RomanNumeral(fromroman(s))
+
+# using Compat: @warn
 function toroman(val::Integer)
     val <= 0 && throw(DomainError(val, "in ancient Rome there were only strictly positive numbers"))
     val > maximum(first(t) for t in NUMERAL_MAP) && @warn("Roman numerals do not handle large numbers well") # instead if maximum, use NUMERAL_MAP[1][1]?

--- a/src/types.jl
+++ b/src/types.jl
@@ -10,7 +10,7 @@ struct RomanNumeral <: Integer
     str::String
     RomanNumeral(int::Integer) = new(int, toroman(int))
     function RomanNumeral(str::AbstractString)
-        num = parse(RomanNumeral, str)
+        num = fromroman(str)
         new(num, toroman(num))
     end
 end


### PR DESCRIPTION
implement the changes proposed by @gpapini-it 

Revert the parse(::RomanNumeral, x) changes because the last commit returned an Int and not a RomanNumeral and added conversion for Floats and more consistent Integer conversion (in particular for Bools).