### PR TITLE
move Primes to weak dependecy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,15 +3,18 @@ uuid = "37834d88-8936-577c-80c9-1066ecf66832"
 authors = ["Anthony Clays <anthonyclays@gmail.com>"]
 version = "0.3.3"
 
-[deps]
+[weakdeps]
 Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
+
+[extensions]
+RomanNumberTheory = "Primes"
 
 [compat]
 Primes = "0.5"
-julia = "1"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Primes"]

--- a/ext/RomanNumberTheory.jl
+++ b/ext/RomanNumberTheory.jl
@@ -1,0 +1,21 @@
+module RomanNumberTheory
+
+using RomanNumerals
+import RomanNumerals.RN
+
+import Primes
+
+# Who knew Romans did number theory
+function Primes.factor(num::RN)
+    factors = Dict{RN,RN}()
+    for (fac, mul) in Primes.factor(num.val)
+        factors[RN(fac)] = RN(mul)
+    end
+    factors
+end
+Primes.primes(num::RN) = map(RN, Primes.primes(num.val))
+
+Base.show(io::IO, ::MIME{Symbol("text/plain")}, f::Dict{RN,RN}) =
+    join(io, isempty(f) ? "I" : [(e == 1 ? "$p" : "$p^$e") for (p,e) in f], " * ")
+
+end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -2,8 +2,6 @@ import Base: ==, isless, <=, <, >,
     +, -, *, ^, max, min, div, %, gcd, lcm,
     isqrt, isodd, iseven, one
 
-using Primes
-
 # Remember that RN is typealiased to RomanNumeral
 
 # Equality operators
@@ -34,13 +32,3 @@ end
 for op in [:isodd, :iseven, :isprime]
     @eval $(op)(num::RN) = $(op)(num.val)
 end
-
-# Who knew Romans did number theory
-function Primes.factor(num::RN)
-    factors = Dict{RN,RN}()
-    for (fac, mul) in factor(num.val)
-        factors[RN(fac)] = RN(mul)
-    end
-    factors
-end
-Primes.primes(num::RN) = map(RN, Primes.primes(num.val))


### PR DESCRIPTION
As it is not necessary for the basic functionality, and makes the package have no dependencies at all.

I also added a method to pretty print a roman prime factorization.